### PR TITLE
#13 - AuditingFields 추출

### DIFF
--- a/src/main/java/com/susu/projectthestyle/domain/Article.java
+++ b/src/main/java/com/susu/projectthestyle/domain/Article.java
@@ -24,9 +24,8 @@ import java.util.Set;
         @Index(columnList = "createdBy"),
 
 } )
-@EntityListeners(AuditingEntityListener.class)
 @Entity
-public class Article {
+public class Article extends AuditingFields{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY) //mysql 에서는 identity로
     private Long id;
@@ -45,11 +44,6 @@ public class Article {
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
     private final Set<ArticleComment> articleComments = new LinkedHashSet<>();
 
-
-    @CreatedDate @Column(nullable = false) private LocalDateTime createdAt; //생성일시
-    @CreatedBy @Column(nullable = false, length = 100) private String createdBy; //생성자
-    @LastModifiedDate @Column(nullable = false) private LocalDateTime modifiedAt; //수정일시
-    @LastModifiedBy @Column(nullable = false, length = 100) private String modifiedBy; //수정자
 
     //hibernate쓸때 기본생성자 필수
     protected Article(){} //코드 밖에서 사용못하도록 protected

--- a/src/main/java/com/susu/projectthestyle/domain/ArticleComment.java
+++ b/src/main/java/com/susu/projectthestyle/domain/ArticleComment.java
@@ -22,19 +22,14 @@ import java.util.Objects;
         @Index(columnList = "createdBy"),
 
 } )
-@EntityListeners(AuditingEntityListener.class)
 @Entity
-public class ArticleComment {
+public class ArticleComment  extends AuditingFields {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY) //mysql 에서는 identity로
     private Long id;
     @Setter @ManyToOne(optional = false) private Article article; // 댓글 삭제되더라도 게시글은 남아있어야 하니 cascade none(기본값) 설정
     @Setter @Column(nullable = false, length = 500) private String content; // 본문
 
-    @CreatedDate @Column(nullable = false) private LocalDateTime createdAt; //생성일시
-    @CreatedBy @Column(nullable = false, length = 100) private String createdBy; //생성자
-    @LastModifiedDate @Column(nullable = false) private LocalDateTime modifiedAt; //수정일시
-    @LastModifiedBy @Column(nullable = false, length = 100) private String modifiedBy; //수정자
 
     protected ArticleComment(){}
 

--- a/src/main/java/com/susu/projectthestyle/domain/AuditingFields.java
+++ b/src/main/java/com/susu/projectthestyle/domain/AuditingFields.java
@@ -1,0 +1,41 @@
+package com.susu.projectthestyle.domain;
+
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class AuditingFields {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt; //생성일시
+
+    @CreatedBy
+    @Column(nullable = false, updatable = false, length = 100)
+    private String createdBy; //생성자
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt; //수정일시
+
+    @LastModifiedBy
+    @Column(nullable = false, length = 100)
+    private String modifiedBy; //수정자
+
+}


### PR DESCRIPTION
생성자, 생성일시, 수정자, 수정일시는 반복적으로
엔티티 클래스에 들어가는 요소이고, 
도메인과 직접 연관이 없는 요소이므로 추출이가능하다.
'@MappedSuperclass'
그 외 @DateTimeFormat' 요소 추가 및 jpa 옵션 추가